### PR TITLE
conda env readcounts awk to bioawk

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -93,7 +93,7 @@ process {
     }
 
     withName: 'CAT_READCOUNTS' {
-        conda = 'bioconda::awk'
+        conda = 'bioconda::bioawk'
         container = { 
             if (workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container) {
                 'https://depot.galaxyproject.org/singularity/ubuntu:22.04'


### PR DESCRIPTION
Read count process crashed over awk when using conda; changed awk into bioawk.