### PR TITLE
add maxforks for local executor

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -225,7 +225,25 @@ profiles {
     beast {
         max_cpus               = 80
         max_memory             = '200.GB'
+        process {
+            withLabel: 'metaphlan' {
+                maxForks = 2
+            }
+            withLabel: 'humann' {
+                maxForks = 2
+            }
+        }
 
+    }
+    local {
+        process {
+            withLabel: 'metaphlan' {
+                maxForks = 2
+            }
+            withLabel: 'humann' {
+                maxForks = 2
+            }
+        }
     }
     dkfz_plus {
         max_cpus                   = 124


### PR DESCRIPTION
Add a maxForks parameter to the 'beast' profile and the 'local' profile, to ensure that not too many processes of metaphlan and humann are started at the same time. When this happens on a local machine, this can cause OOM issues.
